### PR TITLE
Replace mixin with inventory tick

### DIFF
--- a/src/main/java/xyz/aikoyori/wenospeakumbrellarino/item/UmbrellaItem.java
+++ b/src/main/java/xyz/aikoyori/wenospeakumbrellarino/item/UmbrellaItem.java
@@ -1,5 +1,7 @@
 package xyz.aikoyori.wenospeakumbrellarino.item;
 
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -14,14 +16,35 @@ public class UmbrellaItem extends Item {
 
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
-        if(!world.isClient)
-        {
+        if (!world.isClient) {
             ItemStack stc = user.getStackInHand(hand);
             boolean isUpLol = stc.getOrCreateNbt().getBoolean("isOpen");
-            stc.getOrCreateNbt().putBoolean("isOpen",!isUpLol);
+            stc.getOrCreateNbt().putBoolean("isOpen", !isUpLol);
         }
         return super.use(world, user, hand);
     }
 
 
+    @Override
+    public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
+        if (entity instanceof LivingEntity liv) {
+            //If this stack isn't being held, do nothing
+            if(liv.getMainHandStack() != stack && liv.getOffHandStack() != stack)
+                return;
+
+            //Check if the umbrella is open...
+            var isOpen = stack.getOrCreateNbt().getBoolean("isOpen");
+
+            //If it is, and we're falling...
+            if (liv.getVelocity().getY() < 0) {
+                if(isOpen){
+                    //Reduce vertical velocity!
+                    liv.setVelocity(liv.getVelocity().multiply(1,0.8,1));
+                    liv.onLanding();
+                }
+            }
+        }
+
+        super.inventoryTick(stack, world, entity, slot, selected);
+    }
 }


### PR DESCRIPTION
There's no need for this mod to use a mixin, it can just use the item's inventory ticking method instead to reduce velocity. This helps with compatibility, especially for my mod Moovy.

PR just replaces the mixin with near-identical logic in the `inventoryTick` method of the item.